### PR TITLE
build(container): upgrade to ubi9/nodejs-22 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG APP_DIR=/opt/app-root/src
 
-FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS frontend_build
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.5 AS frontend_build
 USER root
 WORKDIR /usr/src/app
 ADD console-extensions.json .eslintrc.yml i18next-parser.config.js package.json yarn.lock .prettierrc.yml tsconfig.json webpack.config.ts /usr/src/app
@@ -14,13 +14,13 @@ RUN npm install && yarn install
 RUN cd src/cryostat-web && yarn install && yarn yarn:frzinstall
 RUN yarn build-dev # FIXME this should be 'yarn build', not 'build-dev'
 
-FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS backend_build
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.5 AS backend_build
 USER root
 WORKDIR /usr/src/app
 ADD backend /usr/src/app
 RUN npm ci && npm run build:noCheck
 
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:latest
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.5
 ARG APP_DIR
 ENV SRVDIR="${APP_DIR}"
 COPY --from=backend_build /usr/src/app/node_modules/ "${APP_DIR}"/node_modules


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
