### PR TITLE
feat(pages): add pages for creating recordings, rules, and targets

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -27,8 +27,16 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
-      "path": "/cryostat/dashboard",
+      "path": "/cryostat/",
       "component": { "$codeRef": "DashboardPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/cryostat/d-solo",
+      "component": { "$codeRef": "DashboardSoloPage" }
     }
   },
   {
@@ -43,6 +51,14 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": "/cryostat/topology/create-custom-target",
+      "component": { "$codeRef": "CreateTargetPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": "/cryostat/rules",
       "component": { "$codeRef": "AutomatedRulesPage" }
     }
@@ -51,8 +67,24 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
+      "path": "/cryostat/rules/create",
+      "component": { "$codeRef": "CreateRulesPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
       "path": "/cryostat/recordings",
       "component": { "$codeRef": "RecordingsPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/cryostat/recordings/create",
+      "component": { "$codeRef": "CreateRecordingPage" }
     }
   },
   {
@@ -131,7 +163,7 @@
     "properties": {
       "id": "dashboard",
       "name": "%plugin__cryostat-plugin~Navigation.Dashboard%",
-      "href": "/cryostat/dashboard",
+      "href": "/cryostat/",
       "perspective": "admin",
       "section": "cryostat-section"
     }

--- a/package.json
+++ b/package.json
@@ -94,9 +94,13 @@
       "AboutPage": "./openshift/pages/AboutPage",
       "SettingsPage": "./openshift/pages/SettingsPage",
       "DashboardPage": "./openshift/pages/DashboardPage",
+      "DashboardSoloPage": "./openshift/pages/DashboardSoloPage",
       "TopologyPage": "./openshift/pages/TopologyPage",
+      "CreateTargetPage": "./openshift/pages/CreateTargetPage",
       "AutomatedRulesPage": "./openshift/pages/AutomatedRulesPage",
+      "CreateRulesPage": "./openshift/pages/CreateRulesPage",
       "RecordingsPage": "./openshift/pages/RecordingsPage",
+      "CreateRecordingPage": "./openshift/pages/CreateRecordingPage",
       "ArchivesPage": "./openshift/pages/ArchivesPage",
       "EventsPage": "./openshift/pages/EventsPage",
       "SecurityPage": "./openshift/pages/SecurityPage"

--- a/src/openshift/components/CryostatController.tsx
+++ b/src/openshift/components/CryostatController.tsx
@@ -24,13 +24,64 @@ class CryostatControllerComponent extends React.Component<CryostatControllerProp
 
   private loadCryostat = async (): Promise<void> => {
     await this.getCryostatConfig();
+    this.checkNavHighlighting();
     this.applyUIDefaults();
     this.setDocLayout();
     this.setState({ loaded: true });
   };
 
+  /**
+   * At the moment, nested routes will cause multiple nav items to be highlighted in the Console main navigation.
+   *
+   * This means by default the Dashboard nav item (route /cryostat/) will be highlighted when visiting any of the
+   * Cryostat plugin pages (routes /cryostat/whatever/) in addition to highlighting the currently selected page.
+   *
+   * This function checks the current href, and if it is not a Dashboard page then it will remove the pf-m-current class
+   * from the <a> classList to remove the highlighting. Due to this manual intervention, we also need to ensure that the
+   * pf-m-current returns when routing back to a Dashboard page, as it is not added back automatically.
+   */
+  private checkNavHighlighting = (): void => {
+    const currentHref = window.location.href;
+    if (!this.isDashboardRoute(currentHref)) {
+      this.removeDashboardNavHighlighting();
+    } else {
+      this.addDashboardNavHighlighting();
+    }
+  };
+
+  private isDashboardRoute = (href: string): Boolean => {
+    return href.endsWith('/cryostat') || href.endsWith('/cryostat/') || href.includes('d-solo');
+  };
+
+  // Fetches the currently highlighted nav items, and removes pf-m-current from the Dashboard link if found
+  private removeDashboardNavHighlighting = (): void => {
+    const currentlySelected = document.getElementsByClassName('pf-m-current');
+    for (let i = 0; i < currentlySelected.length; i++) {
+      const href = currentlySelected[i].getAttribute('href');
+      if (!href) {
+        continue;
+      }
+      if (this.isDashboardRoute(href)) {
+        currentlySelected[i].classList.remove('pf-m-current');
+      }
+    }
+  };
+
+  // Fetches the nav link elements, and adds pf-m-current back to the Dashboard link
+  private addDashboardNavHighlighting = (): void => {
+    const navLinks = document.getElementsByClassName('pf-v5-c-nav__link');
+    for (let i = 0; i < navLinks.length; i++) {
+      const href = navLinks[i].getAttribute('href');
+      if (!href) {
+        continue;
+      }
+      if (this.isDashboardRoute(href)) {
+        navLinks[i].classList.add('pf-m-current');
+      }
+    }
+  };
+
   private getCryostatConfig = async (): Promise<void> => {
-    console.warn('this is where we can fetch a config');
     // In Kiali, their Controller has a set of props like setNamespaces, setStatus, etc.,
     // and in this block they go through each and populate them with Kiali data.
     // This information will be dispatched later and set into Kiali action code.

--- a/src/openshift/pages/CreateRecordingPage.tsx
+++ b/src/openshift/pages/CreateRecordingPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '@app/app.css';
+import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
+import CreateRecording from '@app/CreateRecording/CreateRecording';
+
+export default function CreateRecordingPage() {
+  return (
+    <CryostatContainer>
+        <CreateRecording/>
+    </CryostatContainer>
+  );
+}

--- a/src/openshift/pages/CreateRulesPage.tsx
+++ b/src/openshift/pages/CreateRulesPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '@app/app.css';
+import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
+import CreateRule from '@app/Rules/CreateRule';
+
+export default function CreateRulesPage() {
+  return (
+    <CryostatContainer>
+        <CreateRule></CreateRule>
+    </CryostatContainer>
+  );
+}

--- a/src/openshift/pages/CreateTargetPage.tsx
+++ b/src/openshift/pages/CreateTargetPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '@app/app.css';
+import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
+import CreateTarget from '@app/Topology/Actions/CreateTarget';
+
+export default function CreateTargetPage() {
+  return (
+    <CryostatContainer>
+        <CreateTarget/>
+    </CryostatContainer>
+  );
+}

--- a/src/openshift/pages/DashboardSoloPage.tsx
+++ b/src/openshift/pages/DashboardSoloPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '@app/app.css';
+import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
+import DashboardSolo from '@app/Dashboard/DashboardSolo';
+
+export default function DashboardSoloPage() {
+  return (
+    <CryostatContainer>
+      <DashboardSolo/>
+    </CryostatContainer>
+  );
+}

--- a/start-console.sh
+++ b/start-console.sh
@@ -36,7 +36,8 @@ fi
 # Both local Cryostat and Prism will use port 8181, use this as plugin-proxy for development purposes.
 PLUGIN_PROXY='{"services": [
     {"consoleAPIPath": "/api/proxy/plugin/cryostat-plugin/cryostat-plugin-proxy/", "endpoint":"http://localhost:8181"},
-    {"consoleAPIPath": "/api/proxy/plugin/cryostat-plugin/cryostat-plugin-proxy/upstream/", "endpoint":"http://localhost:8181"}
+    {"consoleAPIPath": "/api/proxy/plugin/cryostat-plugin/cryostat-plugin-proxy/upstream/", "endpoint":"http://localhost:8181"},
+    {"consoleAPIPath": "/api/v4/", "endpoint":"http://localhost:8181/api/v4/"}
 ]}'
 
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -90,6 +90,7 @@ const config: Configuration = {
       CRYOSTAT_AUTHORITY: 'http://localhost:8181',
       PREVIEW: process.env.PREVIEW || 'false',
       I18N_NAMESPACE: 'plugin__cryostat-plugin',
+      BASEPATH: 'cryostat'
     }),
     new CopyWebpackPlugin({
       patterns: [{ from: path.resolve(__dirname, 'locales'), to: 'locales' }],


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat-web/pull/1534

## Description of the change:
This change adds a handful of missing pages from cryostat-web into the plugin. These would be the pages for creating targets, rules, and recordings, as well as the solo dashboard page.

I've also updated the `start-console.sh` script with a proxy so that requests for /api/v4 will hit the test/local cryostat.

This PR depends on basepath changes to cryostat-web in: https://github.com/cryostatio/cryostat-web/pull/1534. For the time being, I just have cryostat-web pointing to the current upstream commit because it at least has the react-router changes so these pages should render properly.

I did run into one hiccup with the routing in the Console, it has to do with navigation highlighting. At the moment, if you have a route nested within another route and you visit that other page, both nav items will be highlighted. For us that means that the Dashboard (/cryostat/) gets highlighted whenever you visit any other page too (/cryostat/*). I've added a few functions to the CryostatController to check which nav item is highlighted and remove/add the `pf-m-current` class from the Dashboard `<a>` when required.

## Motivation for the change:
This change gets one step closer to the main cryostat-web functionality working within the Console.

## Before

![before](https://github.com/user-attachments/assets/6c1291ac-bd04-4b85-bd8b-e370d8e79acc)

## After

### Create Recording Page
![create-recording](https://github.com/user-attachments/assets/6e34de7c-3b2d-4a4f-98d4-f4fdd414c9e4)

### Create Rule Page
![create-rule](https://github.com/user-attachments/assets/ceece4bd-2e03-4755-b34b-7221ce1f07e5)

### Create Target Page
![create-target](https://github.com/user-attachments/assets/32418e29-d12e-4d7a-a15a-a37e6b033014)

### Dashboard Solo Page
![dashboard-solo](https://github.com/user-attachments/assets/9352063d-7680-4f71-9e96-0d3060959bbd)

### Automated Analysis, this works in the dev setup now when running cryostat locally in dev mode
![automated-analysis](https://github.com/user-attachments/assets/7c3e81c2-e7a1-4418-95f1-fab44e193d26)
