### PR TITLE
fix(backend): correct kubernetes/client-node import

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ popd
 ```bash
 $ export PLUGIN_NAME=cryostat-plugin
 $ export IMAGE_TAG=quay.io/$myusername/cryostat-openshift-console-plugin:latest # replace $myusername with your quay.io username, or else set this to a different repository
-$ MANIFEST=$IMAGE_TAG ./build.bash
+$ PLATFORMS=linux/amd64 MANIFEST=$IMAGE_TAG ./build.bash
 $ podman manifest push $IMAGE_TAG
 $ helm upgrade --set plugin.image=$IMAGE_TAG -i $PLUGIN_NAME charts/openshift-console-plugin -n plugin--${PLUGIN_NAME,,} --create-namespace
 $ helm uninstall $PLUGIN_NAME -n plugin--${PLUGIN_NAME,,}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,7 +15,7 @@
  */
 import { http, https } from 'follow-redirects';
 import fs from 'fs';
-import k8s from '@kubernetes/client-node';
+import * as k8s from '@kubernetes/client-node';
 import express from 'express';
 import morgan from 'morgan';
 import qs from 'qs';


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
Fixes up an import statement. Without this, since the recent linting cleanups, the backend fails to start because the transpiled `new k8s.KubeConfig()` results in an `undefined` dereference.
