### PR TITLE
ci(push): fixup registry push only on push event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,7 @@ jobs:
           echo "::set-output name=tags::${TAGS[@]}"
       - name: Push to registry
         id: push-to-registry
+        if: inputs.push-container
         uses: redhat-actions/push-to-registry@v2
         with:
           image: cryostat-openshift-console-plugin


### PR DESCRIPTION
See #58

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
