### PR TITLE
ci(tags): do not use ref name as container tag in PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      additional-tags:
+        required: false
+        type: string
+        default: ''
 
 env:
   CI_USER: cryostat+bot
@@ -79,7 +83,7 @@ jobs:
         with:
           image: quay.io/cryostat/cryostat-openshift-console-plugin
           oci: true
-          tags: ${{ github.sha }} ${{ github.ref_name }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
+          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
           archs: ${{ inputs.container-archs }}
           containerfiles: |
             ./Dockerfile

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -18,3 +18,4 @@ jobs:
       # TODO build multiarch. This is extremely slow since a lot of cross-compilation needs to be done, and image layer caching is not set up or well supported.
       container-archs: amd64
       push-container: true
+      additional-tags: ${{ github.ref_name }}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
