### PR TITLE
feat(plugin): dynamic lookup of ConsolePlugin CR

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,7 +23,7 @@ import { Duplex } from 'stream';
 
 const app = express();
 const port = process.env.PORT || 9943;
-const skipTlsVerify = process.env.SKIP_TLS_VERIFY == 'true';
+const skipTlsVerify = process.env.NODE_TLS_REJECT_UNAUTHORIZED == '0';
 const htmlDir = process.env.HTML_DIR || './html';
 const tlsCertPath = process.env.TLS_CERT_PATH || '/var/cert/tls.crt';
 const tlsKeyPath = process.env.TLS_KEY_PATH || '/var/cert/tls.key';
@@ -34,7 +34,7 @@ const tlsOpts = {
 };
 
 const kc = new k8s.KubeConfig();
-kc.loadFromDefault();
+kc.loadFromCluster();
 kc.applyToHTTPSOptions({
   rejectUnauthorized: !skipTlsVerify,
 });
@@ -75,7 +75,7 @@ app.use('/upstream/*', async (req, res) => {
     !(svcLabels['app.kubernetes.io/part-of'] === 'cryostat' && svcLabels['app.kubernetes.io/component'] === 'cryostat')
   ) {
     throw new Error(
-      `Selected Service "${name}" in namspace "${ns}" does not have the expected Cryostat selector labels`,
+      `Selected Service "${name}" in namespace "${ns}" does not have the expected Cryostat selector labels`,
     );
   }
 
@@ -161,7 +161,7 @@ app.use('/upstream/*', async (req, res) => {
 });
 
 const svc = https.createServer(tlsOpts, app).listen(port, () => {
-  console.log(`Service started on port ${port}`);
+  console.log(`Service started on port ${port} using ${tlsCertPath}`);
 });
 
 svc.on('connection', (connection) => {

--- a/charts/openshift-console-plugin/templates/clusterrole.yaml
+++ b/charts/openshift-console-plugin/templates/clusterrole.yaml
@@ -7,15 +7,9 @@ metadata:
     {{- include "openshift-console-plugin.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - "operator.cryostat.io"
+  - ""
   resources:
-  - cryostats
+  - services
   verbs:
   - get
   - list
-- apiGroups:
-  - "operator.cryostat.io"
-  resources:
-  - cryostats/status
-  verbs:
-  - get

--- a/src/openshift/pages/ExamplePage.tsx
+++ b/src/openshift/pages/ExamplePage.tsx
@@ -195,7 +195,7 @@ export default function ExamplePage() {
           <TextInput
             value={path}
             type="text"
-            placeholder="/api/v3/targets"
+            placeholder="/api/v4/targets"
             onChange={(_evt, value) => setPath(value)}
           />
           <Button onClick={getBackendHealth}>Test Backend</Button>

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -43,6 +43,7 @@ interface ConsolePluginInstance {
 
 export class ApiService {
   constructor(private readonly _pluginInstance = new ReplaySubject<ConsolePluginInstance>()) {
+    this._pluginInstance.subscribe(cryostatConsolePlugin => console.debug({ pluginInstance: cryostatConsolePlugin }));
     from(k8sGet({ model: CONSOLE_PLUGIN_MODEL, name: PLUGIN_NAME }))
       .pipe(
         first(),

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -36,9 +36,9 @@ const CONSOLE_PLUGIN_MODEL = {
 const PLUGIN_NAME = 'cryostat-plugin'; // this should match the consolePlugin.name in package.json
 
 interface ConsolePluginInstance {
-  alias: string;
-  name: string;
-  ns: string;
+  pluginName: string;
+  proxyAlias: string;
+  proxyNamespace: string;
 }
 
 export class ApiService {
@@ -84,9 +84,9 @@ export class ApiService {
       )
       .subscribe((pluginInstance: any) => {
         this._pluginInstance.next({
-          alias: pluginInstance.spec.proxy[0].alias,
-          name: pluginInstance.meta.name,
-          ns: pluginInstance.spec.proxy[0].endpoint.service.namespace,
+          proxyAlias: pluginInstance.spec.proxy[0].alias,
+          pluginName: pluginInstance.meta.name,
+          proxyNamespace: pluginInstance.spec.proxy[0].endpoint.service.namespace,
         });
       });
   }
@@ -140,7 +140,7 @@ export class ApiService {
   private proxyUrl(requestPath: string): Observable<string> {
     return this._pluginInstance.pipe(
       first(),
-      map((instance) => `/api/proxy/plugin/${instance.name}/${instance.alias}/${requestPath}`),
+      map((instance) => `/api/proxy/plugin/${instance.pluginName}/${instance.proxyAlias}/${requestPath}`),
     );
   }
 }

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -92,6 +92,9 @@ export class ApiService {
         }),
         map((v) => {
           if (Array.isArray(v)) {
+            if (v.length !== 1) {
+              console.warn(`Expected to find one ConsolePlugin named ${PLUGIN_NAME}, found: ${v.length}`);
+            }
             return v[0];
           }
           return v;

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -13,51 +13,134 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { from, of, Observable } from 'rxjs';
+import { from, of, Observable, ReplaySubject, first, map } from 'rxjs';
 import { catchError, concatMap } from 'rxjs/operators';
-import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+import { consoleFetch, k8sGet, K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
+
+const CONSOLE_PLUGIN_MODEL = {
+  label: 'ConsolePlugin',
+  labelKey: 'public~ConsolePlugin',
+  apiVersion: 'v1',
+  apiGroup: 'console.openshift.io',
+  plural: 'consoleplugins',
+  abbr: 'CP',
+  namespaced: false,
+  kind: 'ConsolePlugin',
+  id: 'consoleplugin',
+  labelPlural: 'ConsolePlugins',
+  labelPluralKey: 'public~ConsolePlugins',
+  crd: true,
+  verbs: ['delete', 'deletecollection', 'get', 'list', 'patch', 'create', 'update', 'watch'] as K8sVerb[],
+};
+
+const PLUGIN_NAME = 'cryostat-plugin'; // this should match the consolePlugin.name in package.json
+
+interface ConsolePluginInstance {
+  alias: string;
+  name: string;
+  ns: string;
+}
 
 export class ApiService {
+  constructor(private readonly _pluginInstance = new ReplaySubject<ConsolePluginInstance>()) {
+    from(k8sGet({ model: CONSOLE_PLUGIN_MODEL, name: PLUGIN_NAME }))
+      .pipe(
+        first(),
+        map((v) => {
+          if (!v) {
+            throw new Error();
+          }
+          if (v.hasOwnProperty('items')) {
+            return v['items'];
+          }
+          return v;
+        }),
+        map((v) => {
+          if (Array.isArray(v)) {
+            return v[0];
+          }
+          return v;
+        }),
+        catchError((err) => {
+          console.error(err);
+          return of({
+            meta: {
+              name: PLUGIN_NAME,
+            },
+            spec: {
+              proxy: [
+                {
+                  alias: `${PLUGIN_NAME}-proxy`,
+                  endpoint: {
+                    service: {
+                      namespace: `plugin--${PLUGIN_NAME}`,
+                    },
+                  },
+                },
+              ],
+            },
+          });
+        }),
+      )
+      .subscribe((pluginInstance: any) => {
+        this._pluginInstance.next({
+          alias: pluginInstance.spec.proxy[0].alias,
+          name: pluginInstance.meta.name,
+          ns: pluginInstance.spec.proxy[0].endpoint.service.namespace,
+        });
+      });
+  }
+
   status(): Observable<string> {
-    const url = this.proxyUrl('health');
-    return from(
-      consoleFetch(url.toString(), {
-        method: 'GET',
-        redirect: 'follow',
-      }),
-    ).pipe(
-      concatMap((resp: Response) => (resp.ok ? resp.text() : of(resp.statusText))),
-      catchError((err) => {
-        console.error(err);
-        return JSON.stringify(err);
-      }),
-    );
+    return this.proxyUrl('health')
+      .pipe(
+        concatMap((url) =>
+          from(
+            consoleFetch(url.toString(), {
+              method: 'GET',
+              redirect: 'follow',
+            }),
+          ),
+        ),
+      )
+      .pipe(
+        concatMap((resp: Response) => (resp.ok ? resp.text() : of(resp.statusText))),
+        catchError((err) => {
+          console.error(err);
+          return JSON.stringify(err);
+        }),
+      );
   }
 
   cryostat(ns: string, name: string, method: string, requestPath: string, _body?: object): Observable<string> {
-    const url = this.proxyUrl(`upstream/${requestPath}`);
-    return from(
-      consoleFetch(url.toString(), {
-        method,
-        redirect: 'follow',
-        headers: {
-          'CRYOSTAT-SVC-NS': ns,
-          'CRYOSTAT-SVC-NAME': name,
-        },
-      }),
-    ).pipe(
-      concatMap((resp: Response) => (resp.ok ? resp.text() : of(resp.statusText))),
-      catchError((err) => {
-        console.error(err);
-        return JSON.stringify(err);
-      }),
-    );
+    return this.proxyUrl(`upstream/${requestPath}`)
+      .pipe(
+        concatMap((url) =>
+          from(
+            consoleFetch(url, {
+              method,
+              redirect: 'follow',
+              headers: {
+                'CRYOSTAT-SVC-NS': ns,
+                'CRYOSTAT-SVC-NAME': name,
+              },
+            }),
+          ),
+        ),
+      )
+      .pipe(
+        concatMap((resp: Response) => (resp.ok ? resp.text() : of(resp.statusText))),
+        catchError((err) => {
+          console.error(err);
+          return JSON.stringify(err);
+        }),
+      );
   }
 
-  private proxyUrl(requestPath: string): string {
-    const pluginName = 'cryostat-plugin'; // this must match the consolePlugin.name in package.json
-    const proxyAlias = 'cryostat-plugin-proxy'; // this must match the .spec.proxy.alias in the ConsolePlugin CR
-    const url = `/api/proxy/plugin/${pluginName}/${proxyAlias}/${requestPath}`;
-    return url;
+  private proxyUrl(requestPath: string): Observable<string> {
+    return this._pluginInstance.pipe(
+      first(),
+      map((instance) => `/api/proxy/plugin/${instance.name}/${instance.alias}/${requestPath}`),
+    );
   }
 }

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -15,9 +15,9 @@
  */
 import { from, of, Observable, ReplaySubject, first, map } from 'rxjs';
 import { catchError, concatMap } from 'rxjs/operators';
-import { consoleFetch, k8sGet, K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
+import { consoleFetch, k8sGet, K8sModel, K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 
-const CONSOLE_PLUGIN_MODEL = {
+const CONSOLE_PLUGIN_MODEL: K8sModel = {
   label: 'ConsolePlugin',
   labelKey: 'public~ConsolePlugin',
   apiVersion: 'v1',

--- a/src/openshift/services/ApiService.tsx
+++ b/src/openshift/services/ApiService.tsx
@@ -43,7 +43,7 @@ interface ConsolePluginInstance {
 
 export class ApiService {
   constructor(private readonly _pluginInstance = new ReplaySubject<ConsolePluginInstance>()) {
-    this._pluginInstance.subscribe(cryostatConsolePlugin => console.debug({ pluginInstance: cryostatConsolePlugin }));
+    this._pluginInstance.subscribe((cryostatConsolePlugin) => console.debug({ pluginInstance: cryostatConsolePlugin }));
     from(k8sGet({ model: CONSOLE_PLUGIN_MODEL, name: PLUGIN_NAME }))
       .pipe(
         first(),
@@ -84,6 +84,7 @@ export class ApiService {
         }),
       )
       .subscribe((pluginInstance: any) => {
+        console.debug({ pluginInstance });
         this._pluginInstance.next({
           proxyAlias: pluginInstance.spec.proxy[0].alias,
           pluginName: pluginInstance.meta.name,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #3
Related to https://github.com/cryostatio/cryostat-operator/pull/1023

## Description of the change:
The console plugin UI now looks up ConsolePlugin CR instances in the cluster, specifically for one named `cryostat-plugin`, and uses this to determine the location of the plugin frontend proxy service. This is the cluster-managed service which points to the plugin backend, which is the Cryostat CR proxy that the plugin requests should be routed to.

## Motivation for the change:
This allows the UI to correctly locate the frontend proxy that it should send requests to, even if that proxy may not be running in the typical `plugin--cryostat-plugin` namespace. This may be the case when the Operator has installed the plugin into the cluster, in which case the plugin backend is likely running in the Operator's installation namespace rather than a dedicated plugin namespace.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
