### PR TITLE
ci(runner): split build across per-arch runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,10 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Install buildah
+        run: |
+          sudo apt -y update
+          sudo apt -y install buildah
       - name: Build container
         id: container-build
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,10 +72,10 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install buildah
+      - name: Install buildah and podman
         run: |
           sudo apt -y update
-          sudo apt -y install buildah
+          sudo apt -y install buildah podman
       - name: Build container
         id: container-build
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
           extra-args: |
             --jobs=2
       - name: Save container image
-        run: podman save -o ${{ github.sha }}-${{ matrix.arch }}.tar --format oci-archive ${{ env.CI_IMG }}:${{ github.sh }}-${{ matrix.arch }}
+        run: podman save -o ${{ github.sha }}-${{ matrix.arch }}.tar --format oci-archive ${{ env.CI_IMG }}:${{ github.sha }}-${{ matrix.arch }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}-${{ matrix.arch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,6 @@ name: Container Build
 on:
   workflow_call:
     inputs:
-      container-archs:
-        required: false
-        type: string
-        default: 'amd64, arm64'
       push-container:
         required: false
         type: boolean
@@ -20,6 +16,7 @@ env:
   CI_USER: cryostat+bot
   CI_REGISTRY: quay.io/cryostat
   CI_IMG: quay.io/cryostat/cryostat-openshift-console-plugin
+  IMG_NAME: cryostat-openshift-console-plugin
 
 jobs:
   format-check:
@@ -65,15 +62,12 @@ jobs:
       - run: yarn type-check:plugin
 
   build-container:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
-      - name: Install podman 4 and qemu
-        run: |
-          sudo apt update
-          sudo apt -y satisfy "podman (>= 4.0), qemu-user-static"
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -82,21 +76,63 @@ jobs:
         id: container-build
         uses: redhat-actions/buildah-build@v2
         with:
-          image: quay.io/cryostat/cryostat-openshift-console-plugin
+          image: ${{ env.CI_IMG }}
           oci: true
-          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }} ${{ inputs.additional-tags }}
-          archs: ${{ inputs.container-archs }}
+          tags: ${{ github.sha }}-${{ matrix.arch }}
+          archs: ${{ matrix.arch }}
           containerfiles: |
             ./Dockerfile
           extra-args: |
             --jobs=2
+      - name: Save container image
+        run: podman save -o ${{ github.sha }}-${{ matrix.arch }}.tar --format oci-archive ${{ env.CI_IMG }}:${{ github.sh }}-${{ matrix.arch }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-${{ matrix.arch }}
+          path: ${{ github.sha }}-${{ matrix.arch }}.tar
+
+  publish-manifest:
+    runs-on: ubuntu-latest
+    needs: [build-container]
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    steps:
+      - name: Download container tarballs
+        uses: actions/download-artifact@v4
+        with:
+          path: containers
+          pattern: ${{ github.sha }}-*
+          merge-multiple: true
+      - name: Create manifest
+        run: podman manifest create ${{ env.CI_IMG }}:${{ github.sha }}
+      - name: Import container tarballs to manifest
+        run: |
+          find containers -type f -exec podman load -i {} \;
+          for tag in $(podman images --filter label=io.cryostat.component --format '{{ .Tag }}'); do
+            podman manifest add ${{ env.CI_IMG }}:${{ github.sha }} containers-storage:${{ env.CI_IMG }}:${tag}
+          done
+      - name: Set manifest tags
+        id: manifest-tags
+        run: |
+          TAGS=()
+          if [ '${{ github.ref }}' == 'refs/heads/main' ]; then
+            TAGS+=("latest")
+          fi
+          for tag in ${{ inputs.additional-tags }}; do
+            TAGS+=("${tag}")
+          done
+          echo "::set-output name=tags::${TAGS[@]}"
+      - name: Tag manifest
+        run: |
+          for tag in ${{ steps.manifest-tags.outputs.tags }}; do
+            podman tag ${{ env.CI_IMG }}:${{ github.sha }} ${{ env.CI_IMG }}:${tag}
+          done
       - name: Push to registry
         id: push-to-registry
         if: inputs.push-container
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: cryostat-openshift-console-plugin
-          tags: ${{ steps.container-build.outputs.tags }}
+          image: ${{ env.IMG_NAME }}
+          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }} ${{ inputs.additional-tags }}
           registry: ${{ env.CI_REGISTRY }}
           username: ${{ env.CI_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -12,5 +12,3 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/ci.yaml
-    with:
-      container-archs: amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN npm ci && npm run build
 FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.5
 ARG APP_DIR
 ENV SRVDIR="${APP_DIR}"
+LABEL io.cryostat.component=console-plugin
 COPY --from=backend_build /usr/src/app/node_modules/ "${APP_DIR}"/node_modules
 COPY --from=backend_build /usr/src/app/dist/server.js "${APP_DIR}"
 COPY --from=frontend_build /usr/src/app/dist "${APP_DIR}"/html


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/786
Related to https://github.com/cryostatio/cryostat-operator/issues/611

## Description of the change:
Splits up the CI job for building containers, so that each arch (amd64 and arm64) for the multiarch manifest is built in parallel, and on a native-arch runner rather than cross-compiling using qemu.

## Motivation for the change:
Very significantly faster build. Sequentially building the two archs on an amd64 runner usually takes about an hour total, but this time is heavily dominated by the emulation slowdown of cross-compilation running under qemu. With this change each build takes a bit over 10 minutes, and since they are done in parallel, the total CI completion time goes from over an hour to just over 10 minutes.

Sample runs:
Before: https://github.com/cryostatio/cryostat-openshift-console-plugin/actions/runs/13016113128
After: https://github.com/andrewazores/cryostat-openshift-console-plugin/actions/runs/13016583361 (result - https://quay.io/repository/andrewazores/cryostat-openshift-console-plugin?tab=tags)
