### PR TITLE
feat(selector): extract CryostatSelector into its own component

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
   publish-manifest:
     runs-on: ubuntu-latest
     needs: [build-container]
-    if: ${{ github.repository_owner == 'cryostatio' }}
+    if: ${{ github.repository_owner == 'cryostatio' && inputs.push-container}}
     steps:
       - name: Download container tarballs
         uses: actions/download-artifact@v4
@@ -132,7 +132,6 @@ jobs:
           done
       - name: Push to registry
         id: push-to-registry
-        if: inputs.push-container
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMG_NAME }}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -69,7 +69,10 @@ app.use('/upstream/*', async (req, res) => {
     name = name[0];
   }
 
-  const svc = await k8sApi.readNamespacedService(name, ns);
+  const svc = await k8sApi.readNamespacedService(name, ns).catch((err) => {
+    console.error(err);
+    throw err;
+  });
   const svcLabels = svc?.body?.metadata?.labels ?? {};
   if (
     !(svcLabels['app.kubernetes.io/part-of'] === 'cryostat' && svcLabels['app.kubernetes.io/component'] === 'cryostat')
@@ -137,6 +140,9 @@ app.use('/upstream/*', async (req, res) => {
       Referer: req.headers.referer,
     },
   };
+  console.log(
+    `Proxying <${ns}, ${name}> ${method} ${req.path} -> ${tls ? 'https' : 'http'}://${host}:${svcPort}${path}`,
+  );
   const options = {
     ...initOptions,
     agent: new proto.Agent(initOptions),

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -28,14 +28,19 @@ import { ReportService } from '@app/Shared/Services/Report.service';
 import { TargetsService } from '@app/Shared/Services/Targets.service';
 import { pluginServices } from '@console-plugin/services/PluginContext';
 import { Observable } from 'rxjs';
+import CryostatSelector from './CryostatSelector';
+
+export type CryostatService = {
+  name: string;
+  namespace: string;
+};
 
 export const pluginContext: CryostatContext = {
   url: (path?: string): Observable<string> => pluginServices.plugin.proxyUrl(`upstream/${path}`),
   headers: () => {
     const headers = new Headers({
-      // TODO populate these with context selections, maybe taken from redux or localstorage
-      'CRYOSTAT-SVC-NS': '',
-      'CRYOSTAT-SVC-NAME': '',
+      'CRYOSTAT-SVC-NS': localStorage.getItem('cryostat-svc-ns') || '',
+      'CRYOSTAT-SVC-NAME': localStorage.getItem('cryostat-svc-name') || '',
     });
     return headers;
   },
@@ -60,11 +65,14 @@ const services: Services = {
 };
 
 export const CryostatContainer: React.FC = ({ children }) => {
+  const [service, setService] = React.useState({ namespace: '', name: '' } as CryostatService);
+  localStorage.setItem('cryostat-svc-ns', service.namespace);
+  localStorage.setItem('cryostat-svc-name', service.name);
   return (
     <ServiceContext.Provider value={services}>
+      <CryostatSelector setSelectedCryostat={setService} />
       <Provider store={store}>
-        {/* TODO: set-up the CR selector, and any other component Cryostat-web might need */}
-        <CryostatController>{children}</CryostatController>
+        <CryostatController key={`${service.namespace}-${service.name}`}>{children}</CryostatController>
       </Provider>
     </ServiceContext.Provider>
   );

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -30,6 +30,9 @@ import { pluginServices } from '@console-plugin/services/PluginContext';
 import { Observable } from 'rxjs';
 import CryostatSelector from './CryostatSelector';
 
+const SESSIONSTORAGE_SVC_NS_KEY = 'cryostat-svc-ns';
+const SESSIONSTORAGE_SVC_NAME_KEY = 'cryostat-svc-name';
+
 export type CryostatService = {
   name: string;
   namespace: string;
@@ -39,8 +42,8 @@ export const pluginContext: CryostatContext = {
   url: (path?: string): Observable<string> => pluginServices.plugin.proxyUrl(`upstream/${path}`),
   headers: () => {
     const headers = new Headers({
-      'CRYOSTAT-SVC-NS': localStorage.getItem('cryostat-svc-ns') || '',
-      'CRYOSTAT-SVC-NAME': localStorage.getItem('cryostat-svc-name') || '',
+      'CRYOSTAT-SVC-NS': sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) || '',
+      'CRYOSTAT-SVC-NAME': sessionStorage.getItem(SESSIONSTORAGE_SVC_NAME_KEY) || '',
     });
     return headers;
   },
@@ -66,8 +69,8 @@ const services: Services = {
 
 export const CryostatContainer: React.FC = ({ children }) => {
   const [service, setService] = React.useState({ namespace: '', name: '' } as CryostatService);
-  localStorage.setItem('cryostat-svc-ns', service.namespace);
-  localStorage.setItem('cryostat-svc-name', service.name);
+  sessionStorage.setItem(SESSIONSTORAGE_SVC_NS_KEY, service.namespace);
+  sessionStorage.setItem(SESSIONSTORAGE_SVC_NAME_KEY, service.name);
   return (
     <ServiceContext.Provider value={services}>
       <CryostatSelector setSelectedCryostat={setService} />

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -29,6 +29,8 @@ import { TargetsService } from '@app/Shared/Services/Targets.service';
 import { pluginServices } from '@console-plugin/services/PluginContext';
 import { Observable } from 'rxjs';
 import CryostatSelector from './CryostatSelector';
+import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
+import { DisconnectedIcon } from '@patternfly/react-icons';
 
 const SESSIONSTORAGE_SVC_NS_KEY = 'cryostat-svc-ns';
 const SESSIONSTORAGE_SVC_NAME_KEY = 'cryostat-svc-name';
@@ -36,6 +38,11 @@ const SESSIONSTORAGE_SVC_NAME_KEY = 'cryostat-svc-name';
 export type CryostatService = {
   name: string;
   namespace: string;
+};
+
+export const NO_INSTANCE: CryostatService = {
+  name: '',
+  namespace: '',
 };
 
 export const pluginContext: CryostatContext = {
@@ -67,19 +74,47 @@ const services: Services = {
   login,
 };
 
+const EmptyState: React.FC = () => {
+  return (
+    <>
+      <Card>
+        <CardTitle>
+          <DisconnectedIcon />
+          &nbsp; No instance selected
+        </CardTitle>
+        <CardBody>
+          <Text component={TextVariants.p}>To view this content, select a Cryostat instance.</Text>
+        </CardBody>
+      </Card>
+    </>
+  );
+};
+
 export const CryostatContainer: React.FC = ({ children }) => {
-  const [service, setService] = React.useState({ namespace: '', name: '' } as CryostatService);
+  const [service, setService] = React.useState(NO_INSTANCE);
 
   React.useLayoutEffect(() => {
     sessionStorage.setItem(SESSIONSTORAGE_SVC_NS_KEY, service.namespace);
     sessionStorage.setItem(SESSIONSTORAGE_SVC_NAME_KEY, service.name);
   }, [sessionStorage, service]);
 
+  React.useEffect(() => {
+    console.log({ service });
+  }, [service]);
+
+  const noSelection = React.useMemo(() => {
+    return service.namespace == NO_INSTANCE.namespace && service.name == NO_INSTANCE.name;
+  }, [service]);
+
   return (
     <ServiceContext.Provider value={services}>
       <CryostatSelector setSelectedCryostat={setService} />
       <Provider store={store}>
-        <CryostatController key={`${service.namespace}-${service.name}`}>{children}</CryostatController>
+        {noSelection ? (
+          <EmptyState />
+        ) : (
+          <CryostatController key={`${service.namespace}-${service.name}`}>{children}</CryostatController>
+        )}
       </Provider>
     </ServiceContext.Provider>
   );

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -98,10 +98,6 @@ export const CryostatContainer: React.FC = ({ children }) => {
     sessionStorage.setItem(SESSIONSTORAGE_SVC_NAME_KEY, service.name);
   }, [sessionStorage, service]);
 
-  React.useEffect(() => {
-    console.log({ service });
-  }, [service]);
-
   const noSelection = React.useMemo(() => {
     return service.namespace == NO_INSTANCE.namespace && service.name == NO_INSTANCE.name;
   }, [service]);

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -47,10 +47,11 @@ export const NO_INSTANCE: CryostatService = {
 
 export const pluginContext: CryostatContext = {
   url: (path?: string): Observable<string> => pluginServices.plugin.proxyUrl(`upstream/${path}`),
-  headers: () => new Headers({
-    'CRYOSTAT-SVC-NS': sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) || '',
-    'CRYOSTAT-SVC-NAME': sessionStorage.getItem(SESSIONSTORAGE_SVC_NAME_KEY) || '',
-  }),
+  headers: () =>
+    new Headers({
+      'CRYOSTAT-SVC-NS': sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) || '',
+      'CRYOSTAT-SVC-NAME': sessionStorage.getItem(SESSIONSTORAGE_SVC_NAME_KEY) || '',
+    }),
 };
 
 const target = new TargetService();

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -69,8 +69,12 @@ const services: Services = {
 
 export const CryostatContainer: React.FC = ({ children }) => {
   const [service, setService] = React.useState({ namespace: '', name: '' } as CryostatService);
-  sessionStorage.setItem(SESSIONSTORAGE_SVC_NS_KEY, service.namespace);
-  sessionStorage.setItem(SESSIONSTORAGE_SVC_NAME_KEY, service.name);
+
+  React.useLayoutEffect(() => {
+    sessionStorage.setItem(SESSIONSTORAGE_SVC_NS_KEY, service.namespace);
+    sessionStorage.setItem(SESSIONSTORAGE_SVC_NAME_KEY, service.name);
+  }, [sessionStorage, service]);
+
   return (
     <ServiceContext.Provider value={services}>
       <CryostatSelector setSelectedCryostat={setService} />

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -47,13 +47,10 @@ export const NO_INSTANCE: CryostatService = {
 
 export const pluginContext: CryostatContext = {
   url: (path?: string): Observable<string> => pluginServices.plugin.proxyUrl(`upstream/${path}`),
-  headers: () => {
-    const headers = new Headers({
-      'CRYOSTAT-SVC-NS': sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) || '',
-      'CRYOSTAT-SVC-NAME': sessionStorage.getItem(SESSIONSTORAGE_SVC_NAME_KEY) || '',
-    });
-    return headers;
-  },
+  headers: () => new Headers({
+    'CRYOSTAT-SVC-NS': sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) || '',
+    'CRYOSTAT-SVC-NAME': sessionStorage.getItem(SESSIONSTORAGE_SVC_NAME_KEY) || '',
+  }),
 };
 
 const target = new TargetService();

--- a/src/openshift/components/CryostatController.tsx
+++ b/src/openshift/components/CryostatController.tsx
@@ -29,7 +29,7 @@ class CryostatControllerComponent extends React.Component<CryostatControllerProp
     this.loadCryostat();
   }
 
-  componentWillUntmount(): void {
+  componentWillUnmount(): void {
     // do nothing for now.
   }
 

--- a/src/openshift/components/CryostatSelector.tsx
+++ b/src/openshift/components/CryostatSelector.tsx
@@ -23,7 +23,6 @@ import {
   SelectList,
   SelectOption,
 } from '@patternfly/react-core';
-import { Subscription } from 'rxjs';
 import {
   K8sResourceCommon,
   NamespaceBar,
@@ -40,7 +39,6 @@ export default function CryostatSelector({
 }: {
   setSelectedCryostat: React.Dispatch<React.SetStateAction<CryostatService>>;
 }) {
-  const [subs] = React.useState([] as Subscription[]);
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
   const [searchNamespace] = useActiveNamespace();
   const [selector, setSelector] = React.useState('');
@@ -60,12 +58,6 @@ export default function CryostatSelector({
       },
     },
   });
-
-  React.useEffect(() => {
-    return () => {
-      subs.forEach((s) => s.unsubscribe());
-    };
-  }, [subs]);
 
   React.useEffect(() => {
     let selector = localStorage.getItem(LOCALSTORAGE_KEY);

--- a/src/openshift/components/CryostatSelector.tsx
+++ b/src/openshift/components/CryostatSelector.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
+import { Subscription } from 'rxjs';
+import {
+  K8sResourceCommon,
+  NamespaceBar,
+  useActiveNamespace,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { CryostatService } from './CryostatContainer';
+const ALL_NS = '#ALL_NS#';
+
+const LOCALSTORAGE_KEY = 'cryostat-plugin';
+
+export default function CryostatSelector({
+  setSelectedCryostat,
+}: {
+  setSelectedCryostat: React.Dispatch<React.SetStateAction<CryostatService>>;
+}) {
+  const [subs] = React.useState([] as Subscription[]);
+  const [dropdownOpen, setDropdownOpen] = React.useState(false);
+  const [searchNamespace] = useActiveNamespace();
+  const [selector, setSelector] = React.useState('');
+  const [instances] = useK8sWatchResource<K8sResourceCommon[]>({
+    isList: true,
+    namespaced: true,
+    namespace: searchNamespace === ALL_NS ? undefined : searchNamespace,
+    groupVersionKind: {
+      group: '',
+      kind: 'Service',
+      version: 'v1',
+    },
+    selector: {
+      matchLabels: {
+        'app.kubernetes.io/part-of': 'cryostat',
+        'app.kubernetes.io/component': 'cryostat',
+      },
+    },
+  });
+
+  React.useEffect(() => {
+    return () => {
+      subs.forEach((s) => s.unsubscribe());
+    };
+  }, [subs]);
+
+  React.useEffect(() => {
+    const selector = localStorage.getItem(LOCALSTORAGE_KEY);
+    const selectedNs = selector?.split(',')[0] || '';
+    const selectedName = selector?.split(',')[1] || '';
+    setSelectedCryostat({ namespace: selectedNs, name: selectedName });
+    if (selector) {
+      setSelector(selector);
+    }
+  }, [localStorage, setSelector, setSelectedCryostat]);
+
+  const instance = React.useMemo(() => {
+    const selectedNs = selector.split(',')[0];
+    const selectedName = selector.split(',')[1];
+    for (const c of instances) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (c.metadata.namespace === selectedNs && c.metadata.name === selectedName) {
+        return c;
+      }
+    }
+    return undefined;
+  }, [instances, selector]);
+
+  const instanceSelect = React.useCallback(
+    (_, svc: K8sResourceCommon) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const selector = `${svc.metadata.namespace},${svc.metadata.name}`;
+      const selectedNs = selector?.split(',')[0] || '';
+      const selectedName = selector?.split(',')[1] || '';
+      localStorage.setItem(LOCALSTORAGE_KEY, selector);
+      setSelector(selector);
+      setDropdownOpen(false);
+      setSelectedCryostat({ namespace: selectedNs, name: selectedName });
+    },
+    [setSelector, setDropdownOpen, setSelectedCryostat],
+  );
+
+  const dropdownToggle = () => {
+    setDropdownOpen(!dropdownOpen);
+  };
+
+  const renderLabel = React.useCallback(
+    (svc: K8sResourceCommon): string => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (svc.metadata === undefined) {
+        svc.metadata = {};
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return searchNamespace === ALL_NS ? `${svc.metadata.name} (${svc.metadata.namespace})` : svc.metadata.name;
+    },
+    [searchNamespace],
+  );
+
+  const selectToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle ref={toggleRef} onClick={dropdownToggle} isExpanded={dropdownOpen} isDisabled={instances.length === 0}>
+      {instance ? renderLabel(instance) : 'Cryostats'}
+    </MenuToggle>
+  );
+
+  return (
+    <>
+      <NamespaceBar onNamespaceChange={() => setSelector('')}>
+        <Select
+          isOpen={dropdownOpen}
+          selected={selector}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          onSelect={instanceSelect}
+          onOpenChange={setDropdownOpen}
+          toggle={selectToggle}
+          shouldFocusToggleOnSelect
+        >
+          <SelectList>
+            {instances.map((svc) => (
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              <SelectOption value={svc} key={svc.metadata.name}>
+                {renderLabel(svc)}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </NamespaceBar>
+    </>
+  );
+}

--- a/src/openshift/services/PluginService.tsx
+++ b/src/openshift/services/PluginService.tsx
@@ -77,7 +77,6 @@ interface ConsolePluginInstance {
 
 export class PluginService {
   constructor(private readonly _pluginInstance = new ReplaySubject<ConsolePluginInstance>()) {
-    this._pluginInstance.subscribe((cryostatConsolePlugin) => console.debug({ pluginInstance: cryostatConsolePlugin }));
     from(k8sGet({ model: CONSOLE_PLUGIN_MODEL, name: PLUGIN_NAME }))
       .pipe(
         first(),
@@ -122,7 +121,6 @@ export class PluginService {
         }),
       )
       .subscribe((pluginInstance: ConsolePluginCustomResource) => {
-        console.debug({ pluginInstance });
         this._pluginInstance.next({
           proxyAlias: pluginInstance.spec.proxy[0].alias,
           pluginName: pluginInstance.metadata.name,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,10 +87,12 @@ const config: Configuration = {
   plugins: [
     new ConsoleRemotePlugin(),
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: 'http://localhost:8181',
+      CRYOSTAT_AUTHORITY: isProd
+        ? 'upstream/api/proxy/plugin/cryostat-plugin/cryostat-plugin-proxy'
+        : 'http://localhost:8181',
       PREVIEW: process.env.PREVIEW || 'false',
       I18N_NAMESPACE: 'plugin__cryostat-plugin',
-      BASEPATH: 'cryostat'
+      BASEPATH: 'cryostat',
     }),
     new CopyWebpackPlugin({
       patterns: [{ from: path.resolve(__dirname, 'locales'), to: 'locales' }],
@@ -117,10 +119,7 @@ function combineLocaleFiles(files: string[]) {
   });
   combined = flatten(combined);
   try {
-    fs.writeFileSync(
-      './locales/en/plugin__cryostat-plugin.json',
-      JSON.stringify(combined, null, 2),
-    );
+    fs.writeFileSync('./locales/en/plugin__cryostat-plugin.json', JSON.stringify(combined, null, 2));
   } catch (e) {
     console.error('Could not write plugin__cryostat-plugin.json', e);
   }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,9 +87,7 @@ const config: Configuration = {
   plugins: [
     new ConsoleRemotePlugin(),
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: isProd
-        ? 'upstream/api/proxy/plugin/cryostat-plugin/cryostat-plugin-proxy'
-        : 'http://localhost:8181',
+      CRYOSTAT_AUTHORITY: isProd ? undefined : 'http://localhost:8181',
       PREVIEW: process.env.PREVIEW || 'false',
       I18N_NAMESPACE: 'plugin__cryostat-plugin',
       BASEPATH: 'cryostat',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
Adds a CryostatSelector component that updates the current page on selection of a Cryostat service.

It is a trimmed down version of the existing ExamplePage to only include the relevant parts required for selecting services. There is a state object to hold the service information that is passed into the CryostatSelector from the CryostatContainer, and is used as the key for the CryostatController. The idea here is that when the CryostatSelector has a new service picked it will update the state and cause a re-render of the CryostatController to update the page.

I've also updated the webpack config for production builds to set CRYOSTAT_AUTHORITY with the required path to hit the backend service.

## Motivation for the change:
This change wires up the CryostatContext with the required service information to retrieve information from Cryostats running in OpenShift.
