### PR TITLE
fix(Dockerfile): use yarn build instead of build-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,14 @@ ARG APP_DIR=/opt/app-root/src
 FROM registry.access.redhat.com/ubi9/nodejs-22:9.5 AS frontend_build
 USER root
 WORKDIR /usr/src/app
-ADD console-extensions.json .eslintrc.yml i18next-parser.config.js package.json yarn.lock .prettierrc.yml tsconfig.json webpack.config.ts /usr/src/app
+ADD console-extensions.json .eslintrc.yml i18next-parser.config.js package.json yarn.lock .prettierrc.yml tsconfig.json webpack.config.ts /usr/src/app/
 ADD locales /usr/src/app/locales
 ADD i18n-scripts /usr/src/app/i18n-scripts
 ADD src/openshift /usr/src/app/src/openshift
 ADD src/cryostat-web /usr/src/app/src/cryostat-web
 RUN (command -v corepack || npm install --global corepack) && \
     corepack enable
-RUN npm install && yarn install
-RUN cd src/cryostat-web && yarn install && yarn yarn:frzinstall
-RUN yarn build-dev # FIXME this should be 'yarn build', not 'build-dev'
+RUN npm install && yarn install && yarn build
 
 FROM registry.access.redhat.com/ubi9/nodejs-22:9.5 AS backend_build
 USER root

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,7 +87,7 @@ const config: Configuration = {
   plugins: [
     new ConsoleRemotePlugin(),
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: isProd ? undefined : 'http://localhost:8181',
+      CRYOSTAT_AUTHORITY: isProd ? '' : 'http://localhost:8181',
       PREVIEW: process.env.PREVIEW || 'false',
       I18N_NAMESPACE: 'plugin__cryostat-plugin',
       BASEPATH: 'cryostat',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
Uses `yarn build` instead of `yarn build-dev` for the container build.

Previously, `yarn build` was resulting in errors due to the style attributes of some of the cryostat-web SVG classes. I noticed this only seemed to happen if my cryostat-web had installed its own dependencies. What looks to have happened is that the console plugin is ending up with csstype v3.1.3, which has a different type structure of text-align than the versions before it, and cryostat-web was pulling in v3.1.1.

v3.1.3 (https://github.com/frenic/csstype/blob/v3.1.3/index.d.ts#L20023)
`export type TextAlign = Globals | "-webkit-match-parent" | "center" | "end" | "justify" | "left" | "match-parent" | "right" | "start";`

v3.1.1 (https://github.com/frenic/csstype/blob/v3.1.1/index.d.ts#L19051)
` export type TextAlign = Globals | "center" | "end" | "justify" | "left" | "match-parent" | "right" | "start";`

Because the console plugin only uses the cryostat-web code, there shouldn't be a need to install its dependencies. 

Also running `yarn build` complained that CRYOSTAT_AUTHORITY couldn't be undefined, so it's set here to an empty string in production.

