### PR TITLE
feat(selector): add button to open standalone Cryostat Web UI

### DIFF
--- a/src/openshift/components/CryostatSelector.tsx
+++ b/src/openshift/components/CryostatSelector.tsx
@@ -24,7 +24,6 @@ import {
   SelectOption,
   Split,
   SplitItem,
-  Text,
   Tooltip,
 } from '@patternfly/react-core';
 import {
@@ -102,6 +101,7 @@ export default function CryostatSelector({
     })
       .catch((_) => '')
       .then(
+        /* eslint-disable  @typescript-eslint/no-explicit-any */
         (route: any) => {
           const ingresses = route?.status?.ingress;
           let res = '';

--- a/src/openshift/components/CryostatSelector.tsx
+++ b/src/openshift/components/CryostatSelector.tsx
@@ -22,11 +22,17 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Split,
+  SplitItem,
+  Text,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
+  k8sGet,
   K8sResourceCommon,
   NamespaceBar,
   useActiveNamespace,
+  useK8sModel,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -35,6 +41,8 @@ import {
   SESSIONSTORAGE_SVC_NAME_KEY,
   SESSIONSTORAGE_SVC_NS_KEY,
 } from './CryostatContainer';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
 const ALL_NS = '#ALL_NS#';
 
 export default function CryostatSelector({
@@ -45,6 +53,7 @@ export default function CryostatSelector({
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
   const [searchNamespace] = useActiveNamespace();
   const [selector, setSelector] = React.useState('');
+  const [routeModel] = useK8sModel({ group: 'route.openshift.io', version: 'v1', kind: 'Route' });
   const [instances] = useK8sWatchResource<K8sResourceCommon[]>({
     isList: true,
     namespaced: true,
@@ -61,6 +70,7 @@ export default function CryostatSelector({
       },
     },
   });
+  const [routeUrl, setRouteUrl] = React.useState('');
 
   React.useEffect(() => {
     let selectedNs = sessionStorage.getItem(SESSIONSTORAGE_SVC_NS_KEY) ?? '';
@@ -77,6 +87,34 @@ export default function CryostatSelector({
     }
     setSelector(`${selectedNs},${selectedName}`);
   }, [sessionStorage, setSelectedCryostat, instances, searchNamespace]);
+
+  React.useEffect(() => {
+    const selectedNs = selector.split(',')[0];
+    const selectedName = selector.split(',')[1];
+    if (!selectedNs || !selectedName) {
+      setRouteUrl('');
+      return;
+    }
+    k8sGet({
+      model: routeModel,
+      name: selectedName,
+      ns: selectedNs,
+    })
+      .catch((_) => '')
+      .then(
+        (route: any) => {
+          const ingresses = route?.status?.ingress;
+          let res = '';
+          if (ingresses && ingresses?.length > 0 && ingresses[0]?.host) {
+            res = `http://${ingresses[0].host}`;
+          }
+          setRouteUrl(res);
+        },
+        (_) => {
+          setRouteUrl('');
+        },
+      );
+  }, [selector, setRouteUrl]);
 
   const instance = React.useMemo(() => {
     const selectedNs = selector.split(',')[0];
@@ -137,31 +175,46 @@ export default function CryostatSelector({
   return (
     <>
       <NamespaceBar onNamespaceChange={() => setSelector('')}>
-        <Select
-          isOpen={dropdownOpen}
-          selected={selector}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          onSelect={instanceSelect}
-          onOpenChange={setDropdownOpen}
-          toggle={selectToggle}
-          shouldFocusToggleOnSelect
-        >
-          <SelectList>
-            {instances.map((svc) => (
+        <Split hasGutter>
+          <SplitItem>
+            <Select
+              isOpen={dropdownOpen}
+              selected={selector}
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
-              <SelectOption value={svc} key={svc.metadata.name}>
-                {renderLabel(svc)}
-              </SelectOption>
-            ))}
-            <MenuFooter>
-              <Button variant="link" isInline onClick={clearSelection}>
-                Clear Selection
-              </Button>
-            </MenuFooter>
-          </SelectList>
-        </Select>
+              onSelect={instanceSelect}
+              onOpenChange={setDropdownOpen}
+              toggle={selectToggle}
+              shouldFocusToggleOnSelect
+            >
+              <SelectList>
+                {instances.map((svc) => (
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  <SelectOption value={svc} key={svc.metadata.name}>
+                    {renderLabel(svc)}
+                  </SelectOption>
+                ))}
+                <MenuFooter>
+                  <Button variant="link" isInline onClick={clearSelection}>
+                    Clear Selection
+                  </Button>
+                </MenuFooter>
+              </SelectList>
+            </Select>
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content="Open the standalone Cryostat Web UI for this instance in a new tab. This is only available if the selected Cryostat instance has an associated Route.">
+              <Button
+                isAriaDisabled={!routeUrl}
+                component="a"
+                href={routeUrl}
+                target="_blank"
+                icon={<ExternalLinkAltIcon />}
+              />
+            </Tooltip>
+          </SplitItem>
+        </Split>
       </NamespaceBar>
     </>
   );

--- a/src/openshift/services/PluginService.tsx
+++ b/src/openshift/services/PluginService.tsx
@@ -186,7 +186,8 @@ export class PluginService {
           const url = new URL(requestPath ?? '');
           // we only want the path and the parts that come after, the rest is handled by proxying
           return `${url.pathname}${url.search}${url.hash}`;
-        } catch (err) {
+          /* eslint-disable  @typescript-eslint/no-unused-vars */
+        } catch (_) {
           // requestPath is empty or a relative path, so just use the adjusted proxied path
           return proxiedPath;
         }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #3

## Description of the change:
Adds a button on the context selector bar that allows for opening a new browser tab pointed at the Cryostat instance's Route. If there is no Route (located by looking in the same Service Namespace, for a Route with the same name as the Service) or if the URL from the Route cannot be determined, then the button is disabled.

(helm installed, with route)
![image](https://github.com/user-attachments/assets/60c1d433-b504-40ea-aafc-a65fe9b25652)

(helm installed, no route)
![image](https://github.com/user-attachments/assets/cbb82fb3-3740-4a31-af78-f2cab447db05)

(operator installed, with route)
![image](https://github.com/user-attachments/assets/89b1aa0b-cac3-4074-b36d-9b8645181850)

## Motivation for the change:
Not all functionality is exposed through the plugin UI. For example, file uploads (rules as JSON, custom event templates, or JFR files for archives) do not work. This is because console plugins must go through the Fetch API and pass various additional headers to the console backend proxy, which then passes to the plugin backend - but these file upload requests use XMLHttpRequest (XHR) and not the Fetch API. XHR allows for request upload progress and Fetch does not, so for these upload operations and large JFR uploads in particular the Fetch API for uploading is not a suitable substitute. However, passing the custom headers needed to the XHR function does result in the client code setting the request headers, but the browser does not honour them and they are not actually sent to the console backend proxy. This works fine in the standalone UI case because there is no console proxy and additional headers (ex. X-CSRFToken) are not requried, so the XHR requests complete normally.

Separate PRs will follow to hide or disable these functions from the plugin's UI. This button allows the user to quickly jump over to the full Cryostat UI where they can complete these upload tasks as needed.
