### PR TITLE
chore(build): remove npm install from frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ADD src/openshift /usr/src/app/src/openshift
 ADD src/cryostat-web /usr/src/app/src/cryostat-web
 RUN (command -v corepack || npm install --global corepack) && \
     corepack enable
-RUN npm install && yarn install && yarn build
+RUN echo "nodeLinker: node-modules" > .yarnrc.yml
+RUN yarn install && yarn build
 
 FROM registry.access.redhat.com/ubi9/nodejs-22:9.5 AS backend_build
 USER root


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
This PR removes the npm install step from the Dockerfile, which takes roughly ~5 minutes to complete on my machine, whereas yarn install is about 1 minute.

At the moment it isn't enough to just remove the `npm install` step, because when I took a look into the container the `yarn install` step by itself wasn't generating the node_modules folder. It turns out it's missing the .yarnrc.yml file with the nodeLinker, and after this change the yarn install can be used by itself to fetch all the dependencies.

## Motivation for the change:
This speeds up the container build.
