### PR TITLE
feat(notifications): rough implementation of notification toasts

### DIFF
--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -24,7 +24,7 @@ import { SettingsService } from '@app/Shared/Services/Settings.service';
 import { LoginService } from '@app/Shared/Services/Login.service';
 import { ApiService } from '@app/Shared/Services/Api.service';
 import { NotificationsContext, NotificationsInstance } from '@app/Shared/Services/Notifications.service';
-import { Notification } from '@app/Shared/Services/api.types';
+import { Notification, NotificationCategory } from '@app/Shared/Services/api.types';
 import { NotificationChannel } from '@app/Shared/Services/NotificationChannel.service';
 import { ReportService } from '@app/Shared/Services/Report.service';
 import { TargetsService } from '@app/Shared/Services/Targets.service';
@@ -142,7 +142,15 @@ const NotificationGroup: React.FC = () => {
               .filter((n) => n.title != 'Target List Update Failed')
               // some API requests, like querying for JMC Agent presence in a selected target,
               // are expected to respond with failure status codes. Suppress these notifications.
-              .filter((n) => n.title != 'Request failed');
+              .filter((n) => n.title != 'Request failed')
+              // disable any notifications the user has specifically turned off
+              .filter((n) => services.settings.notificationsEnabledFor(NotificationCategory[n.category || '']))
+              // order chronologically
+              .sort((prev, curr) => {
+                if (!prev.timestamp) return -1;
+                if (!curr.timestamp) return 1;
+                return prev.timestamp - curr.timestamp;
+              });
 
             // ensure we are only displaying unique notifications. Sometimes the plugin initialization
             // is buggy and we get more than one WebSocket connection, or more than one NotificationChannel

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -155,7 +155,7 @@ const NotificationGroup: React.FC = () => {
   return (
     <AlertGroup isToast isLiveRegion>
       {notifications.slice(0, 3).map(({ key, title, message, variant }) => (
-        <Alert isLiveRegion variant={variant} key={key} title={title} timeout={2000}>
+        <Alert isLiveRegion variant={variant} key={key} title={title} timeout={5000}>
           {message?.toString()}
         </Alert>
       ))}

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -145,7 +145,7 @@ const NotificationGroup: React.FC = () => {
             const byKey = _.uniqBy(visible, 'key');
             const byMessage = _.uniqBy(byKey, 'message');
 
-            return byMessage;
+            return byMessage.slice(0, 5);
           }),
         )
         .subscribe((n) => setNotifications([...n])),
@@ -154,7 +154,7 @@ const NotificationGroup: React.FC = () => {
 
   return (
     <AlertGroup isToast isLiveRegion>
-      {notifications.slice(0, 3).map(({ key, title, message, variant }) => (
+      {notifications.map(({ key, title, message, variant }) => (
         <Alert isLiveRegion variant={variant} key={key} title={title} timeout={5000}>
           {message?.toString()}
         </Alert>

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -111,12 +111,18 @@ const NotificationGroup: React.FC = () => {
   const services = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
   const [notifications, setNotifications] = React.useState([] as Notification[]);
+  const [visibleNotificationsCount, setVisibleNotificationsCount] = React.useState(5);
+
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
     services.notificationChannel.disconnect();
     services.notificationChannel.connect();
   }, [services.notificationChannel]);
+
+  React.useEffect(() => {
+    addSubscription(services.settings.visibleNotificationsCount().subscribe(setVisibleNotificationsCount));
+  }, [addSubscription, services.settings, setVisibleNotificationsCount]);
 
   React.useEffect(() => {
     addSubscription(
@@ -145,12 +151,12 @@ const NotificationGroup: React.FC = () => {
             const byKey = _.uniqBy(visible, 'key');
             const byMessage = _.uniqBy(byKey, 'message');
 
-            return byMessage.slice(0, 5);
+            return byMessage.slice(0, visibleNotificationsCount);
           }),
         )
         .subscribe((n) => setNotifications([...n])),
     );
-  }, [notificationsContext, addSubscription]);
+  }, [notificationsContext, addSubscription, visibleNotificationsCount]);
 
   return (
     <AlertGroup isToast isLiveRegion>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #3

## Description of the change:
Hooks up a simplified graphical notification alert group for displaying toast-style notification popup boxes. Since there is no sidebar or pullout notification drawer there is no mechanism for hiding or marking notifications as read, and no "View more" overflow handling. There is some hacky processing of the notifications stream done to try to filter them by the least noisy types and to de-duplicate them (band-aid for still not perfected WebSocket/NotificationChannel handling). There is no way to review notifications after they time out.

## Motivation for the change:
These notifications are used to communicate to the user that actions have been completed, such as creating/stopping/archiving/deleting recordings.

![image](https://github.com/user-attachments/assets/ec9f93bf-8a8f-42d4-becf-9a3fccef7f59)
