### PR TITLE
chore(pages): remove SettingsPage navigation

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -7,14 +7,6 @@
       "component": { "$codeRef": "AboutPage" }
     }
   },
-  // {
-  //   "type": "console.page/route",
-  //   "properties": {
-  //     "exact": true,
-  //     "path": "/cryostat/settings",
-  //     "component": { "$codeRef": "SettingsPage" }
-  //   }
-  // },
   {
     "type": "console.page/route",
     "properties": {
@@ -121,16 +113,6 @@
       "section": "cryostat-section"
     }
   },
-  // {
-  //   "type": "console.navigation/href",
-  //   "properties": {
-  //     "id": "settings",
-  //     "name": "%plugin__cryostat-plugin~Navigation.Settings%",
-  //     "href": "/cryostat/settings",
-  //     "perspective": "admin",
-  //     "section": "cryostat-section"
-  //   }
-  // },
   {
     "type": "console.navigation/href",
     "properties": {

--- a/console-extensions.json
+++ b/console-extensions.json
@@ -7,14 +7,14 @@
       "component": { "$codeRef": "AboutPage" }
     }
   },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "exact": true,
-      "path": "/cryostat/settings",
-      "component": { "$codeRef": "SettingsPage" }
-    }
-  },
+  // {
+  //   "type": "console.page/route",
+  //   "properties": {
+  //     "exact": true,
+  //     "path": "/cryostat/settings",
+  //     "component": { "$codeRef": "SettingsPage" }
+  //   }
+  // },
   {
     "type": "console.page/route",
     "properties": {
@@ -121,16 +121,16 @@
       "section": "cryostat-section"
     }
   },
-  {
-    "type": "console.navigation/href",
-    "properties": {
-      "id": "settings",
-      "name": "%plugin__cryostat-plugin~Navigation.Settings%",
-      "href": "/cryostat/settings",
-      "perspective": "admin",
-      "section": "cryostat-section"
-    }
-  },
+  // {
+  //   "type": "console.navigation/href",
+  //   "properties": {
+  //     "id": "settings",
+  //     "name": "%plugin__cryostat-plugin~Navigation.Settings%",
+  //     "href": "/cryostat/settings",
+  //     "perspective": "admin",
+  //     "section": "cryostat-section"
+  //   }
+  // },
   {
     "type": "console.navigation/href",
     "properties": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "description": "OpenShift Console plugin for Cryostat",
     "exposedModules": {
       "AboutPage": "./openshift/pages/AboutPage",
-      "SettingsPage": "./openshift/pages/SettingsPage",
       "DashboardPage": "./openshift/pages/DashboardPage",
       "DashboardSoloPage": "./openshift/pages/DashboardSoloPage",
       "TopologyPage": "./openshift/pages/TopologyPage",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
The SettingsPage doesn't quite work at the moment, so this PR comments out it's usage in the `console-extensions.json` to be returned when this can be fixed up.

For the time being the console plugin will be like a "default" view of cryostat-web, and if users want to have more fine-grain control over the UI there is the option now to open the dedicated cryostat-web view for a namespace. 