### PR TITLE
chore(service): lazy init

### DIFF
--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -119,7 +119,8 @@ const NotificationGroup: React.FC = () => {
   React.useEffect(() => {
     services.notificationChannel.disconnect();
     services.notificationChannel.connect();
-  }, [services.notificationChannel]);
+    services.targets.queryForTargets().subscribe();
+  }, [services.notificationChannel, services.targets]);
 
   React.useEffect(() => {
     addSubscription(services.settings.visibleNotificationsCount().subscribe(setVisibleNotificationsCount));

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -75,8 +75,8 @@ const services = (svc: CryostatService): Services => {
   const ctx = pluginContext(svc);
   const target = new TargetService();
   const settings = new SettingsService();
-  const login = new LoginService(ctx.url, settings);
   const api = new ApiService(ctx, target, NotificationsInstance);
+  const login = new LoginService(api, settings);
   const notificationChannel = new NotificationChannel(ctx, NotificationsInstance, login);
   const reports = new ReportService(ctx, NotificationsInstance, notificationChannel);
   const targets = new TargetsService(api, NotificationsInstance, notificationChannel);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Depends on https://github.com/cryostatio/cryostat-web/pull/1554

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
