### PR TITLE
fix(grafana): enable "View in Grafana" if Route is available

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -219,7 +219,15 @@ app.use('/upstream/*', async (req, res) => {
     ssl: tlsOpts,
     xfwd: true,
   };
-  const correctedUrl = (req.baseUrl + req.url).replace(/^\/upstream(\.*)/, '');
+  let correctedUrl = (req.baseUrl + req.url).replace(/^\/upstream(\.*)/, '');
+  // normalize
+  while (correctedUrl.includes('//')) {
+    correctedUrl = correctedUrl.replace('//', '/');
+  }
+  if (correctedUrl.endsWith('/')) {
+    // trim trailing slash if any
+    correctedUrl = correctedUrl.substring(0, correctedUrl.length - 1);
+  }
   req.url = correctedUrl;
   console.log(`Proxying <${ns}, ${name}> ${method} ${req.url} -> ${opts.target}`);
   proxy.web(req, res, opts);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -230,10 +230,7 @@ app.use('/upstream/*', async (req, res) => {
   }
   req.url = correctedUrl;
   console.log(`Proxying <${ns}, ${name}> ${method} ${req.url} -> ${opts.target}`);
-  proxy.web(req, res, opts, (err) => {
-    console.log('Proxy server error', err);
-    req.emit('error', err);
-  });
+  proxy.web(req, res, opts);
 });
 
 const svc = https.createServer(tlsOpts, app);
@@ -243,7 +240,7 @@ svc.on('connection', (connection) => {
   connection.on('close', () => (connections = connections.filter((curr) => curr !== connection)));
 });
 svc.on('upgrade', async (req, sock, head) => {
-  console.log(`WebSocket upgrade: ${req.url}`);
+  console.log(`WebSocket Upgrade: ${req.url}`);
   if (!req.url) {
     throw new Error(`Cannot upgrade WebSocket connection to: ${req.url}`);
   }
@@ -261,23 +258,14 @@ svc.on('upgrade', async (req, sock, head) => {
     const correctedUrl = req.url.replace(/^\/upstream(\.*)/, '');
     req.url = correctedUrl;
     console.log(`WebSocket ${req.url} -> ${target}`);
-    proxy.ws(
-      req,
-      sock,
-      head,
-      {
-        target,
-        followRedirects: true,
-        secure: !skipTlsVerify,
-        ssl: tlsOpts,
-      },
-      (err) => {
-        console.error('WebSocket server error', err);
-        req.emit('error', err);
-      },
-    );
+    proxy.ws(req, sock, head, {
+      target,
+      followRedirects: true,
+      secure: !skipTlsVerify,
+      ssl: tlsOpts,
+    });
   } catch (err) {
-    console.error('WebSocket upgrade error', err);
+    console.error(err);
   }
 });
 svc.listen(port, () => {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #110 
Depends on https://github.com/cryostatio/cryostat-web/pull/1557

## Description of the change:
- path handling cleanup in the backend
- use the queried Route to set a capability override for the Grafana dashboard URL. If no Route can be determined then hide the "View in Grafana" action item, since using the console infra proxy doesn't work (described in #110)
- some more general cleanup and refactoring. Notably, removed duplicate `<Provider>` redux components that were added the last time I tried splitting things up

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
