### PR TITLE
fix(nav): move nav highlighting checks from controller to container

### DIFF
--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -61,6 +61,7 @@ import {
   useK8sModel,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { checkNavHighlighting } from '@console-plugin/utils/utils';
 
 export const SESSIONSTORAGE_SVC_NS_KEY = 'cryostat-svc-ns';
 export const SESSIONSTORAGE_SVC_NAME_KEY = 'cryostat-svc-name';
@@ -368,6 +369,6 @@ const NamespacedContainer: React.FC<{ searchNamespace: string; children: React.R
 
 export const CryostatContainer: React.FC = ({ children }) => {
   const [namespace] = useActiveNamespace();
-
+  checkNavHighlighting();
   return <NamespacedContainer searchNamespace={namespace}>{children}</NamespacedContainer>;
 };

--- a/src/openshift/components/CryostatContainer.tsx
+++ b/src/openshift/components/CryostatContainer.tsx
@@ -369,6 +369,6 @@ const NamespacedContainer: React.FC<{ searchNamespace: string; children: React.R
 
 export const CryostatContainer: React.FC = ({ children }) => {
   const [namespace] = useActiveNamespace();
-  checkNavHighlighting();
+  React.useEffect(() => checkNavHighlighting(), []);
   return <NamespacedContainer searchNamespace={namespace}>{children}</NamespacedContainer>;
 };

--- a/src/openshift/components/CryostatController.tsx
+++ b/src/openshift/components/CryostatController.tsx
@@ -39,61 +39,9 @@ class CryostatControllerComponent extends React.Component<CryostatControllerProp
 
   private loadCryostat = async (): Promise<void> => {
     await this.getCryostatConfig();
-    this.checkNavHighlighting();
     this.applyUIDefaults();
     this.setDocLayout();
     this.setState({ loaded: true });
-  };
-
-  /**
-   * At the moment, nested routes will cause multiple nav items to be highlighted in the Console main navigation.
-   *
-   * This means by default the Dashboard nav item (route /cryostat/) will be highlighted when visiting any of the
-   * Cryostat plugin pages (routes /cryostat/whatever/) in addition to highlighting the currently selected page.
-   *
-   * This function checks the current href, and if it is not a Dashboard page then it will remove the pf-m-current class
-   * from the <a> classList to remove the highlighting. Due to this manual intervention, we also need to ensure that the
-   * pf-m-current returns when routing back to a Dashboard page, as it is not added back automatically.
-   */
-  private checkNavHighlighting = (): void => {
-    const currentHref = window.location.href;
-    if (!this.isDashboardRoute(currentHref)) {
-      this.removeDashboardNavHighlighting();
-    } else {
-      this.addDashboardNavHighlighting();
-    }
-  };
-
-  private isDashboardRoute = (href: string): boolean => {
-    return href.endsWith('/cryostat') || href.endsWith('/cryostat/') || href.includes('d-solo');
-  };
-
-  // Fetches the currently highlighted nav items, and removes pf-m-current from the Dashboard link if found
-  private removeDashboardNavHighlighting = (): void => {
-    const currentlySelected = document.getElementsByClassName('pf-m-current');
-    for (let i = 0; i < currentlySelected.length; i++) {
-      const href = currentlySelected[i].getAttribute('href');
-      if (!href) {
-        continue;
-      }
-      if (this.isDashboardRoute(href)) {
-        currentlySelected[i].classList.remove('pf-m-current');
-      }
-    }
-  };
-
-  // Fetches the nav link elements, and adds pf-m-current back to the Dashboard link
-  private addDashboardNavHighlighting = (): void => {
-    const navLinks = document.getElementsByClassName('pf-v5-c-nav__link');
-    for (let i = 0; i < navLinks.length; i++) {
-      const href = navLinks[i].getAttribute('href');
-      if (!href) {
-        continue;
-      }
-      if (this.isDashboardRoute(href)) {
-        navLinks[i].classList.add('pf-m-current');
-      }
-    }
   };
 
   private getCryostatConfig = async (): Promise<void> => {

--- a/src/openshift/utils/utils.ts
+++ b/src/openshift/utils/utils.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isDashboardRoute(href: string) {
+  return href.endsWith('/cryostat') || href.endsWith('/cryostat/') || href.includes('d-solo');
+}
+
+// Fetches the nav link elements, and adds pf-m-current back to the Dashboard link
+function addDashboardNavHighlighting() {
+  const navLinks = document.getElementsByClassName('pf-v5-c-nav__link');
+  for (let i = 0; i < navLinks.length; i++) {
+    const href = navLinks[i].getAttribute('href');
+    if (!href) {
+      continue;
+    }
+    if (isDashboardRoute(href)) {
+      navLinks[i].classList.add('pf-m-current');
+    }
+  }
+}
+
+// Fetches the currently highlighted nav items, and removes pf-m-current from the Dashboard link if found
+function removeDashboardNavHighlighting() {
+  const currentlySelected = document.getElementsByClassName('pf-m-current');
+  for (let i = 0; i < currentlySelected.length; i++) {
+    const href = currentlySelected[i].getAttribute('href');
+    if (!href) {
+      continue;
+    }
+    if (isDashboardRoute(href)) {
+      currentlySelected[i].classList.remove('pf-m-current');
+    }
+  }
+}
+
+/**
+ * At the moment, nested routes will cause multiple nav items to be highlighted in the Console main navigation.
+ *
+ * This means by default the Dashboard nav item (route /cryostat/) will be highlighted when visiting any of the
+ * Cryostat plugin pages (routes /cryostat/whatever/) in addition to highlighting the currently selected page.
+ *
+ * This function checks the current href, and if it is not a Dashboard page then it will remove the pf-m-current class
+ * from the <a> classList to remove the highlighting. Due to this manual intervention, we also need to ensure that the
+ * pf-m-current returns when routing back to a Dashboard page, as it is not added back automatically.
+ */
+export function checkNavHighlighting() {
+  const currentHref = window.location.href;
+  if (!isDashboardRoute(currentHref)) {
+    removeDashboardNavHighlighting();
+  } else {
+    addDashboardNavHighlighting();
+  }
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #118 

## Description of the change:
This change moves the navigation highlighting checks from the CryostatController to the CryostatContainer.

When the checks were originally put in place we didn't yet have the empty state, so I added these checks to occur just prior to the nested pages being rendered. Now that the repo has progressed a lot and there is an empty state that happens in CryostatContainer the checks have to be moved up to that component in order to apply at the same time as the empty states.

## Motivation for the change:
Makes the navigation highlight look as expected.

## Before
![Screenshot from 2025-02-04 15-52-36](https://github.com/user-attachments/assets/6341993e-ec3c-471f-83b4-438706cb601c)

## After
![Screenshot from 2025-02-04 16-07-11](https://github.com/user-attachments/assets/2cbdd976-46d9-46ac-937c-0b9b472a1459)

