### PR TITLE
fix(topology): override css for tab content view

### DIFF
--- a/src/openshift/styles/plugin.css
+++ b/src/openshift/styles/plugin.css
@@ -26,4 +26,15 @@ limitations under the License.
         margin-right: var(--pf-v5-global--spacer--sm);
     }
 }
+
+/** 
+ * Reset the height property of pf-v5-c-drawer__body (overrided by OpenShift console to 100%) 
+ * The topology detail panel relies on flex box property to make the content body fill vertical space and allow scrolling if overflow.
+ * Setting height to 100% breaks the view since the header takes all vertical space instead, resulting no space for body.
+ */
+.topology__main-container {
+    .pf-v5-c-drawer__body {
+        height: unset;
+    }
+}
 /* stylelint-enable */


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #120

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
