### PR TITLE
fix(css): apply missing stylesheets to Topology and Recordings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@cypress/webpack-preprocessor": "^5.15.5",
     "@openshift-console/dynamic-plugin-sdk": "1.4.0",
     "@openshift-console/dynamic-plugin-sdk-webpack": "1.1.1",
+    "@patternfly/patternfly": "^5.4.0",
     "@patternfly/quickstarts": "^5.4.0",
     "@patternfly/react-catalog-view-extension": "^5.0.0",
     "@patternfly/react-charts": "^7.4.5",

--- a/src/openshift/pages/RecordingsPage.tsx
+++ b/src/openshift/pages/RecordingsPage.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '@patternfly/patternfly/components/OverflowMenu/overflow-menu.css';
 import React from 'react';
 import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
 import Recordings from '@app/Recordings/Recordings';

--- a/src/openshift/pages/TopologyPage.tsx
+++ b/src/openshift/pages/TopologyPage.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '@patternfly/patternfly/components/DescriptionList/description-list.css';
 import Topology from '@app/Topology/Topology';
 import React from 'react';
-import '@app/app.css';
 import { CryostatContainer } from '@console-plugin/components/CryostatContainer';
 
 export default function TopologyPage() {

--- a/src/openshift/styles/plugin.css
+++ b/src/openshift/styles/plugin.css
@@ -15,20 +15,8 @@ limitations under the License.
 */
 
 /* stylelint-disable */
-/* TODO: investigate why overflow-menu stylesheets are not being imported with the rest of PF */
-.recording-table-outer-container {
-    .pf-v5-c-overflow-menu__group {
-        display: flex;
-        align-items: center;
-    }
-    
-    .pf-v5-c-overflow-menu__group > .pf-v5-c-overflow-menu__item {
-        margin-right: var(--pf-v5-global--spacer--sm);
-    }
-}
-
 /** 
- * Reset the height property of pf-v5-c-drawer__body (overrided by OpenShift console to 100%) 
+ * Reset the height property of pf-v5-c-drawer__body (overridden by OpenShift console to 100%)
  * The topology detail panel relies on flex box property to make the content body fill vertical space and allow scrolling if overflow.
  * Setting height to 100% breaks the view since the header takes all vertical space instead, resulting no space for body.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/patternfly@npm:^5.4.0":
+  version: 5.4.2
+  resolution: "@patternfly/patternfly@npm:5.4.2"
+  checksum: 1cc2c3f7020f050eb4bd72d57a48473c7fad9c931b16e3c8e8ba7f0d94654d22a1944b3593b6b118a1b28f14749ae6a630622efd6c1cd54b6f08cd360b186cb3
+  languageName: node
+  linkType: hard
+
 "@patternfly/quickstarts@npm:^5.4.0":
   version: 5.4.1
   resolution: "@patternfly/quickstarts@npm:5.4.1"
@@ -3668,6 +3675,7 @@ __metadata:
     "@cypress/webpack-preprocessor": ^5.15.5
     "@openshift-console/dynamic-plugin-sdk": 1.4.0
     "@openshift-console/dynamic-plugin-sdk-webpack": 1.1.1
+    "@patternfly/patternfly": ^5.4.0
     "@patternfly/quickstarts": ^5.4.0
     "@patternfly/react-catalog-view-extension": ^5.0.0
     "@patternfly/react-charts": ^7.4.5


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #[125](https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/125)

## Description of the change:
Applies missing PF css to pages that make use of them. 

DescriptionList -> TopologyPage
Overflow-menu -> RecordingsPage

The console-dynamic-plugin-sdk documentation mentions to _avoid_ directly importing from '@patternfly/patternfly' [link](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/upgrade-PatternFly.md#css-styling) but in this case we're missing stylesheets on a couple of pages.

Taking a look at the PF support [table](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk#openshift-console-versions-vs-patternfly-versions), I'm wondering if the styles applied correctly in 4.19 because they dropped PF4 support starting that version.

## Motivation for the change:
Fixes the formatting of some components where the PF css are missing.

## Screenshots

Topology:
![after-topology](https://github.com/user-attachments/assets/41709a65-c17d-4878-8774-4dd5ea775d0f)

Recordings buttons:
![after-recordings](https://github.com/user-attachments/assets/846d615e-05a4-4976-8d3f-9cafc58a915a)
