### PR TITLE
ci(tags): use package.json version as an image tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMG_NAME }}
-          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }} ${{ inputs.additional-tags }}
+          tags: ${{ github.ref == 'refs/heads/main' && 'latest' || '' }} ${{ inputs.additional-tags }}
           registry: ${{ env.CI_REGISTRY }}
           username: ${{ env.CI_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -10,9 +10,18 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
+  get-build-info:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          TAGS=()
+          TAGS+=("$(jq -r '.version' < package.json)")
+          echo "::set-output name=tags::${TAGS[@]}"
   build:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
+    needs: [get-build-info]
     with:
       push-container: true
-      additional-tags: ${{ github.ref_name }}
+      additional-tags: ${{ github.ref_name }} ${{ needs.get-build-info.outputs.tags }}


### PR DESCRIPTION
- **ci(tags): use package.json version as an image tag**
- **remove commit sha tag**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
