### PR TITLE
fix(backend): default port number in code agrees with config default

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,7 +22,7 @@ import morgan from 'morgan';
 import { ParsedQs, stringify as stringifyQuery } from 'qs';
 import { Duplex } from 'stream';
 
-const port = process.env.PORT || 9943;
+const port = process.env.PORT || 9443;
 const skipTlsVerify = process.env.NODE_TLS_REJECT_UNAUTHORIZED == '0';
 const htmlDir = process.env.HTML_DIR || './html';
 const tlsCertPath = process.env.TLS_CERT_PATH || '/var/cert/tls.crt';


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

The Helm chart defaults to port 9443 for the plugin backend. The Operator also deploys the backend using 9443.

https://github.com/cryostatio/cryostat-openshift-console-plugin/blob/cefcb39d1d5dd7c835ab2ec34f4fa72d50a23b23/charts/openshift-console-plugin/values.yaml#L8

https://github.com/cryostatio/cryostat-openshift-console-plugin/blob/cefcb39d1d5dd7c835ab2ec34f4fa72d50a23b23/charts/openshift-console-plugin/templates/deployment.yaml#L28

https://github.com/cryostatio/cryostat-operator/blob/ebd66022e5317009636a70aa24c601ffb3a26952/config/openshift/console-plugin/deployment-cryostat-plugin.yaml#L37

https://github.com/cryostatio/cryostat-operator/blob/ebd66022e5317009636a70aa24c601ffb3a26952/config/openshift/console-plugin/service-cryostat-plugin.yaml#L16

However, the backend code defaults to *9943* if the `PORT` env. var. is not set, which is confusing and unexpected.
