### PR TITLE
fix(proxy): handle upstream Cryostat connection failures

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -226,7 +226,7 @@ app.use('/upstream/*', async (req, res) => {
   }
   req.url = correctedUrl;
   console.log(`Proxying <${ns}, ${name}> ${method} ${req.url} -> ${opts.target}`);
-  proxy.web(req, res, opts, err => {
+  proxy.web(req, res, opts, (err) => {
     console.error(err);
     res.status(502).send();
   });
@@ -256,15 +256,21 @@ svc.on('upgrade', async (req, sock, head) => {
   const correctedUrl = req.url.replace(/^\/upstream(\.*)/, '');
   req.url = correctedUrl;
   console.log(`WebSocket ${req.url} -> ${target}`);
-  proxy.ws(req, sock, head, {
-    target,
-    followRedirects: true,
-    secure: !skipTlsVerify,
-    ssl: tlsOpts,
-  }, err => {
-    console.error(err);
-    sock.destroy(err);
-  });
+  proxy.ws(
+    req,
+    sock,
+    head,
+    {
+      target,
+      followRedirects: true,
+      secure: !skipTlsVerify,
+      ssl: tlsOpts,
+    },
+    (err) => {
+      console.error(err);
+      sock.destroy(err);
+    },
+  );
 });
 svc.listen(port, () => {
   console.log(`Service started on port ${port} using ${tlsCertPath}`);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #173

## Description of the change:
Improves error handling so that upstream Cryostat connection failures are handled gracefully by the plugin proxy.

## Motivation for the change:
Prevents the plugin proxy from dying so easily (and being restarted by OpenShift, but maybe slowly with some backoff logic) if upstream Cryostat connections fail. This can happen when the upstream Cryostat is not yet ready to accept connections, for example.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
