### PR TITLE
fix(css): override drawer body height for active recordings page analysis report

### DIFF
--- a/src/openshift/styles/plugin.css
+++ b/src/openshift/styles/plugin.css
@@ -25,4 +25,12 @@ limitations under the License.
         height: unset;
     }
 }
+
+/* Reset override height property used by the automated analysis drawer body on Active Recordings page*/
+#active-recording-drawer {
+    .pf-v5-c-drawer__body {
+        height: unset;
+    }
+}
+
 /* stylelint-enable */


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
Similar to https://github.com/cryostatio/cryostat-openshift-console-plugin/pull/123, there is a css rule from the overrides in openshift/console that messes with the layout in the analysis portion of the drawer on the Active Recordings page.

## Motivation for the change:
To better align the styling of the console plugin to cryostat web.

Before (Cryostat web vs. Console plugin):
![Screenshot from 2025-05-13 13-54-52](https://github.com/user-attachments/assets/d9d57cc7-d25a-4d59-b997-065b7d1196b9)

After (Console plugin):
![Screenshot from 2025-05-14 15-35-33](https://github.com/user-attachments/assets/5dac4fde-e847-4357-96c2-309e8408609c)
