### PR TITLE
chore(cypress): update cypress tests to handle pf6 elements

### DIFF
--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -20,18 +20,21 @@ Cypress.Commands.add('login', (username: string, password: string) => {
   // Check if auth is disabled (for a local development environment).
   cy.visit('/'); // visits baseUrl which is set in plugins/index.js
   cy.window().then((win: ConsoleWindowType) => {
-    if (win.SERVER_FLAGS?.authDisabled) {
-      return;
+    if (!win.SERVER_FLAGS?.authDisabled) {
+      // Make sure we clear the cookie in case a previous test failed to logout.
+      cy.clearCookie('openshift-session-token');
+
+      cy.get('#inputUsername').type(username || KUBEADMIN_USERNAME);
+      cy.get('#inputPassword').type(password || Cypress.env('BRIDGE_KUBEADMIN_PASSWORD'));
+      cy.get('button[type=submit]').click();
     }
 
-    // Make sure we clear the cookie in case a previous test failed to logout.
-    cy.clearCookie('openshift-session-token');
-
-    cy.get('#inputUsername').type(username || KUBEADMIN_USERNAME);
-    cy.get('#inputPassword').type(password || Cypress.env('BRIDGE_KUBEADMIN_PASSWORD'));
-    cy.get('button[type=submit]').click();
-
     cy.get(`[data-test="${loginUsername}"]`).should('be.visible');
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test="guided-tour-modal"]').length > 0) {
+        cy.get('[data-test="tour-step-footer-secondary"]').contains('Skip tour').click();
+      }
+    });
   });
 });
 

--- a/cypress/tests/app.cy.ts
+++ b/cypress/tests/app.cy.ts
@@ -33,10 +33,25 @@ describe('Cryostat OpenShift Console Plugin tests', () => {
   });
 
   it('should visit each page without errors', () => {
-    const pages = ['About', 'Dashboard', 'Topology', 'Automated Rules', 'Archives', 'Events', 'Security'];
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').click();
+    const pages = [
+      'Dashboard',
+      'Topology',
+      'Recordings',
+      'Archives',
+      'Events',
+      'Automated Rules',
+      'Reports',
+      'Instrumentation',
+      'Diagnostics',
+      'Analyze Thread Dumps',
+      'Analyze Heap Dumps',
+      'Certificates',
+      'Credentials',
+      'About',
+    ];
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').click();
     pages.forEach((page) => {
-      cy.get('[class="pf-v5-c-nav__link"]').get('[href^="/cryostat"]').contains(page).click();
+      cy.get('[class="pf-v6-c-nav__link"]').get('[href^="/cryostat"]').contains(page).click();
       checkErrors();
     });
   });

--- a/cypress/tests/dashboard-page.cy.ts
+++ b/cypress/tests/dashboard-page.cy.ts
@@ -33,24 +33,24 @@ describe('Dashboard page tests', () => {
   });
 
   it('should have the url /cryostat/', () => {
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').click();
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').click();
     cy.get('[data-test="nav"]').contains('Dashboard').click();
     cy.url().should('include', '/cryostat/');
   });
 
   it('should refresh the metrics charts after 10 seconds', () => {
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').click();
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').get('[data-test="nav"]').contains('Dashboard').click();
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').click();
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').get('[data-test="nav"]').contains('Dashboard').click();
 
     // select the first Cryostat instance, and first target available
     cy.get('div[aria-label="cryostat-selector"]').find('button').click();
     cy.get('div[aria-label="cryostat-selector-dropdown"]').find('button[tabindex="0"]').click();
 
     // select the first Cryostat target available
-    cy.get('button[aria-label="Select Target"]').find('[class="pf-v5-c-menu-toggle__text"]').click();
-    cy.get('div[data-ouia-component-type="PF5/Dropdown"]')
+    cy.get('button[aria-label="Select Target"]').find('[class="pf-v6-c-menu-toggle__text"]').click();
+    cy.get('div[data-ouia-component-type="PF6/Dropdown"]')
       .find('button[tabindex="0"]')
-      .find('span[class=pf-v5-c-menu__item-text]')
+      .find('span[class=pf-v6-c-menu__item-text]')
       .click();
 
     cy.wait(11000); // charts update every 10 seconds
@@ -58,23 +58,23 @@ describe('Dashboard page tests', () => {
   });
 
   it('should refresh the d-solo charts after 10 seconds', () => {
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').click();
-    cy.contains('[class="pf-v5-c-nav__link"]', 'Cryostat').get('[data-test="nav"]').contains('Dashboard').click();
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').click();
+    cy.contains('[class="pf-v6-c-nav__link"]', 'Cryostat').get('[data-test="nav"]').contains('Dashboard').click();
 
     // select the first Cryostat instance, and first target available
     cy.get('div[aria-label="cryostat-selector"]').find('button').click();
     cy.get('div[aria-label="cryostat-selector-dropdown"]').find('button[tabindex="0"]').click();
 
     // select the first Cryostat target available
-    cy.get('button[aria-label="Select Target"]').find('[class="pf-v5-c-menu-toggle__text"]').click();
-    cy.get('div[data-ouia-component-type="PF5/Dropdown"]')
+    cy.get('button[aria-label="Select Target"]').find('[class="pf-v6-c-menu-toggle__text"]').click();
+    cy.get('div[data-ouia-component-type="PF6/Dropdown"]')
       .find('button[tabindex="0"]')
-      .find('span[class=pf-v5-c-menu__item-text]')
+      .find('span[class=pf-v6-c-menu__item-text]')
       .click();
 
     // view the dashboard solo page of the first available metric card
     cy.get('button[aria-label="dashboard action toggle"]').first().click();
-    cy.get('div[data-ouia-component-type="PF5/Dropdown"]').find('button[tabindex="0"]').first().click();
+    cy.get('div[data-ouia-component-type="PF6/Dropdown"]').find('button[tabindex="0"]').first().click();
 
     cy.url().should('include', '/cryostat/d-solo');
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #908 

## Description of the change:
Updates the Cypress tests to check for PF6 elements.

Also clicks off the guided tour that was added in 4.19.

## Motivation for the change:
Lets the Cypress tests run again, useful for testing PRs such as https://github.com/cryostatio/cryostat-openshift-console-plugin/pull/895

## How to manually test:
1. `yarn run start-console`, `yarn run start`, and have a Cryostat installed plus some target
2. `yarn run cypress:headed` or `yarn run cypress:headless`
